### PR TITLE
Update app structure to include API consumption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ group :development, :test do
   gem 'orderly'
   gem 'faker'
   gem 'hirb'
+  gem 'faraday'
+  gem 'json'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,11 @@ GEM
       railties (>= 5.0.0)
     faker (2.16.0)
       i18n (>= 1.6, < 2)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -90,6 +95,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    json (2.5.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     listen (3.1.5)
@@ -109,6 +115,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multipart-post (2.1.1)
     nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
@@ -176,6 +183,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -238,8 +246,10 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   faker
+  faraday
   hirb
   jbuilder (~> 2.5)
+  json
   launchy
   listen (>= 3.0.5, < 3.2)
   orderly
@@ -262,4 +272,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   2.1.4
+   2.2.8

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,10 @@
 class Admin::DashboardController < ApplicationController
 
 	def index
+		@json_commits = GithubService.commits
+
+
+
 		@top_customers = Customer.top_customers
 		@incomplete_invoices = Invoice.incomplete_invoices
 	end

--- a/app/poro/github.rb
+++ b/app/poro/github.rb
@@ -1,0 +1,11 @@
+class Github
+	def initialize(repo_data)
+		@commit = repo_data[:commit]
+		@pull_request = repo_data{}
+	end
+
+	def commit
+		binding.pry
+	end
+	
+end

--- a/app/services/api_service.rb
+++ b/app/services/api_service.rb
@@ -1,0 +1,7 @@
+class ApiService
+	def self.get_data(endpoint)
+		response = Faraday.get(endpoint)
+		data = response.body
+		JSON.parse(data, symbolize_names: true)
+	end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,11 @@
+class GithubService < ApiService
+	def self.commits
+		endpoint = "https://api.github.com/repos/domo2192/little-esty-shop/commits"
+		json = get_data(endpoint)
+
+		@commits = json.map do |commit|
+			Github.new(commit)
+		end
+	end
+
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,6 @@
 <%= link_to "Admin Merchants Index", admin_merchants_path  %><br>
 <%= link_to "Admin Invoices Index", admin_invoices_path  %><br>
+<h4>Commits</h4>
 <h3> Top Customers </h3>
 <%@top_customers.each do |customer|%>
   <p>Name: <%= customer.first_name %> <%= customer.last_name %> -- Total Transactions: <%= customer.count_of_success %></p>


### PR DESCRIPTION
# Adds
-`app/poro`: A place for the definition of Github API to live
- `app/services/`: A place to store the interaction with the Github API 
# Updates
- `app/controllers`: Includes api consumption suite
- `app/views`: basic implementation of github api